### PR TITLE
fix division issue

### DIFF
--- a/Ether.lua
+++ b/Ether.lua
@@ -103,7 +103,7 @@ end
 
 -- Helper Functions
 function convertWeiToEth(wei)
-  return wei / 1000000000000000000
+  return tonumber(wei) / 1000000000000000000
 end
 
 function cryptocompareRequestUrl()


### PR DESCRIPTION
Ether.lua: Ether.lua:106: attempt to div a 'string' with a 'number'

The requestWeiQuantityForEthAddress() function returns json:dictionary()["result"], which is a string representation of the Wei balance. Lua won't automatically convert strings to numbers for arithmetic operations, so you need to explicitly convert it using tonumber().