### PR TITLE
Fix "Unauthorized" price error: switch CryptoCompare → CoinGecko

### DIFF
--- a/Ether.lua
+++ b/Ether.lua
@@ -1,6 +1,6 @@
 -- Inofficial Ethereum Extension for MoneyMoney
 -- Fetches Ether quantity for address via etherscan API
--- Fetches Ether price in EUR via cryptocompare API
+-- Fetches Ether price in EUR via coingecko API
 -- Returns cryptoassets as securities
 --
 -- Username: Ethereum Adresses comma seperated
@@ -30,7 +30,7 @@
 
 
 WebBanking{
-  version = 0.2,
+  version = 0.3,
   description = "Include your Ether as cryptoportfolio in MoneyMoney by providing a Etheradresses (usernme, comma seperated) and etherscan-API-Key (Password)",
   services= { "Ethereum" }
 }
@@ -72,9 +72,9 @@ function RefreshAccount (account, since)
     s[#s+1] = {
       name = address,
       currency = nil,
-      market = "cryptocompare",
+      market = "coingecko",
       quantity = ethQuantity,
-      price = prices["EUR"],
+      price = prices["eur"],
     }
   end
 
@@ -87,10 +87,10 @@ end
 
 -- Querry Functions
 function requestEthPrice()
-  content = connection:request("GET", cryptocompareRequestUrl(), {})
+  content = connection:request("GET", coingeckoRequestUrl(), {})
   json = JSON(content)
 
-  return json:dictionary()
+  return json:dictionary()["ethereum"]
 end
 
 function requestWeiQuantityForEthAddress(ethAddress)
@@ -106,8 +106,8 @@ function convertWeiToEth(wei)
   return tonumber(wei) / 1000000000000000000
 end
 
-function cryptocompareRequestUrl()
-  return "https://min-api.cryptocompare.com/data/price?fsym=ETH&tsyms=EUR,USD"
+function coingeckoRequestUrl()
+  return "https://api.coingecko.com/api/v3/simple/price?ids=ethereum&vs_currencies=eur,usd"
 end
 
 function etherscanRequestUrl(ethAddress)


### PR DESCRIPTION
The price refresh currently fails for everyone with `HTTPS response: Unauthorized`:

```
GET https://min-api.cryptocompare.com/data/price?fsym=ETH&tsyms=EUR,USD
HTTPS response: Unauthorized
```

**Cause:** CryptoCompare folded its API into the CoinDesk Data platform and removed keyless access to the legacy `min-api.cryptocompare.com/data/price` endpoint. It now returns `HTTP 401 {"message":"API key required ... developers.coindesk.com"}`. Nothing in the extension changed — the vendor gated the endpoint, so every refresh errors out.

**Fix:** switch the price lookup to CoinGecko's keyless `simple/price` endpoint, which still works with no API key:

```
GET https://api.coingecko.com/api/v3/simple/price?ids=ethereum&vs_currencies=eur,usd
-> {"ethereum":{"eur":1442.28,"usd":1668.95}}
```

CoinGecko nests the result under the coin id and uses lowercase currency keys, so `requestEthPrice()` now unwraps `["ethereum"]` and the security reads `prices["eur"]`. The Etherscan balance lookup (which still uses the user-supplied API key) is untouched.

8 lines changed, no new dependencies, no API key required for pricing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)